### PR TITLE
keymanager added, removed connectionstring from appsettings

### DIFF
--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Managers/KeyManager.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Managers/KeyManager.cs
@@ -1,0 +1,10 @@
+﻿namespace ValhallaVaultCyberAwareness.Data.Managers
+{
+    public class KeyManager
+    {
+        public string? GetKey(string filepath)
+        {
+            return File.Exists(filepath) ? File.ReadAllText(filepath) : null;
+        }
+    }
+}

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Managers/KeyManager.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Managers/KeyManager.cs
@@ -2,7 +2,8 @@
 {
     public class KeyManager
     {
-        public string? GetKey(string filepath)
+        private readonly string filepath = "C:\\Users\\Skola\\Desktop\\safe.txt";
+        public string? GetKey()
         {
             return File.Exists(filepath) ? File.ReadAllText(filepath) : null;
         }

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Program.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using ValhallaVaultCyberAwareness.Components;
 using ValhallaVaultCyberAwareness.Components.Account;
 using ValhallaVaultCyberAwareness.Data;
+using ValhallaVaultCyberAwareness.Data.Managers;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -24,7 +25,7 @@ builder.Services.AddAuthentication(options =>
     })
     .AddIdentityCookies();
 
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+var connectionString = new KeyManager().GetKey("C:\\Users\\Skola\\Desktop\\safe.txt") ?? throw new ArgumentNullException("The specified path is not valid");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/appsettings.json
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/appsettings.json
@@ -1,7 +1,4 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-ValhallaVaultCyberAwareness-a544f3ce-e006-4484-8652-43415745290f;Trusted_Connection=True;MultipleActiveResultSets=true"
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
Nu har vi säkrat connectionsträngen också, allihopa borde ha rätt credentials till azure databasen, om inte så ba fråga mig så skickar jag det till er, 

här är connections strängen 
`Server=tcp:newtondev.database.windows.net,1433;Initial Catalog=ValhallaCyberAwerenessDb;Persist Security Info=False;User ID=azureuser;Password=your_password;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;`
noga att det är mellan rum mellan User och ID.

Se till nu att lägga en textfil någonstans på era datorer och sedan kopierar ni hela den sökvägen, och lägger in den sökvägen i GetKey metoden i program.cs. där vi hämtar connectionsträngen. 

ersätt filvägen som jag har till er filväg, se till så att det bara är ett `"` innan `C:` eller `D:` och endast ett `"` efter .txt annars kommer inte filvägen stämma.

när ni har dragit ner det nyaste från master så behöver ni lägga till 
`
hashtag Keymanager
KeyManager.cs
`


i er gitignore fil, så att keymanagern inte pushas upp igen